### PR TITLE
Add pytest test for invalid cutoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,17 @@ Install them via pip:
 ```bash
 pip install numpy pandas matplotlib scipy ipywidgets ipython jupyter
 ```
+
+## Running Tests
+
+The unit tests use `pytest`. Install it with pip:
+
+```bash
+pip install pytest
+```
+
+Then run the test suite from the repository root:
+
+```bash
+pytest
+```

--- a/tests/test_aplicar_filtro.py
+++ b/tests/test_aplicar_filtro.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import numpy as np
+import pytest
+
+from aplicacao_filtro import aplicar_filtro_butterworth
+
+
+def test_aplicar_filtro_butterworth_invalid_cutoff():
+    df = pd.DataFrame({'sinal': np.arange(10)})
+    freq_amostragem = 10.0
+    # freq_corte_hz equal to Nyquist frequency should raise ValueError
+    with pytest.raises(ValueError):
+        aplicar_filtro_butterworth(
+            df,
+            'sinal',
+            freq_corte_hz=freq_amostragem / 2,
+            freq_amostragem_hz=freq_amostragem,
+        )
+


### PR DESCRIPTION
## Summary
- add new test directory with a Butterworth filter test
- document how to run pytest in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6866e8df4ff88327b50db79d9211d4d9